### PR TITLE
Refactoring to use a slice of test cases

### DIFF
--- a/find_and_transcode_files_test.go
+++ b/find_and_transcode_files_test.go
@@ -13,43 +13,48 @@ type FixtureParams struct {
 }
 
 func TestGetExclusiveFiles(t *testing.T) {
-	// Test case 1: filesA is empty, filesB is empty
-	testGetExclusiveFiles(t, FixtureParams{
-		SourceList:      []string{},
-		DestinationList: []string{},
-		ExpectedOutput:  []string{},
-	})
+	cases := []struct {
+		Name            string
+		SourceList      []string
+		DestinationList []string
+		ExpectedOutput  []string
+	}{
+		{
+			Name:            "Both file lists are empty",
+			SourceList:      []string{},
+			DestinationList: []string{},
+			ExpectedOutput:  []string{},
+		},
+		{
+			Name:            "Empty source list, destination list has elements",
+			SourceList:      []string{},
+			DestinationList: []string{"file1.txt", "file2.txt"},
+			ExpectedOutput:  []string{},
+		},
+		{
+			Name:            "Source list has elements, empty destination list",
+			SourceList:      []string{"file1.txt", "file2.txt"},
+			DestinationList: []string{},
+			ExpectedOutput:  []string{"file1.txt", "file2.txt"},
+		},
+		{
+			Name:            "Source and destination have common elements",
+			SourceList:      []string{"file1.txt", "file2.txt", "file3.txt"},
+			DestinationList: []string{"file2.txt", "file3.txt", "file4.txt"},
+			ExpectedOutput:  []string{"file1.txt"},
+		},
+		{
+			Name:            "Source and destination have disjoint elements",
+			SourceList:      []string{"file1.txt", "file2.txt", "file3.txt"},
+			DestinationList: []string{"file4.txt", "file5.txt", "file6.txt"},
+			ExpectedOutput:  []string{"file1.txt", "file2.txt", "file3.txt"},
+		},
+	}
 
-	// Test case 2: filesA is empty, filesB has elements
-	testGetExclusiveFiles(t, FixtureParams{
-		SourceList:      []string{},
-		DestinationList: []string{"file1.txt", "file2.txt"},
-		ExpectedOutput:  []string{},
-	})
-
-	// Test case 3: filesA has elements, filesB is empty
-	testGetExclusiveFiles(t, FixtureParams{
-		SourceList:      []string{"file1.txt", "file2.txt"},
-		DestinationList: []string{},
-		ExpectedOutput:  []string{"file1.txt", "file2.txt"},
-	})
-
-	// Test case 4: filesA and filesB have common elements
-	testGetExclusiveFiles(t, FixtureParams{
-		SourceList:      []string{"file1.txt", "file2.txt", "file3.txt"},
-		DestinationList: []string{"file2.txt", "file3.txt", "file4.txt"},
-		ExpectedOutput:  []string{"file1.txt"},
-	})
-
-	// Test case 5: filesA and filesB have no common elements
-	testGetExclusiveFiles(t, FixtureParams{
-		SourceList:      []string{"file1.txt", "file2.txt", "file3.txt"},
-		DestinationList: []string{"file4.txt", "file5.txt", "file6.txt"},
-		ExpectedOutput:  []string{"file1.txt", "file2.txt", "file3.txt"},
-	})
-}
-
-func testGetExclusiveFiles(t *testing.T, params FixtureParams) {
-	result := getExclusiveFiles(params.SourceList, params.DestinationList)
-	assert.Equal(t, params.ExpectedOutput, result)
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			result := getExclusiveFiles(c.SourceList, c.DestinationList)
+			assert.Equal(t, c.ExpectedOutput, result)
+		})
+	}
 }

--- a/find_and_transcode_files_test.go
+++ b/find_and_transcode_files_test.go
@@ -6,12 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type FixtureParams struct {
-	SourceList      []string
-	DestinationList []string
-	ExpectedOutput  []string
-}
-
 func TestGetExclusiveFiles(t *testing.T) {
 	cases := []struct {
 		Name            string


### PR DESCRIPTION
This is how I would tackle the test cases. You can create an anonymous struct that contains the input value to the method and the expected results. This avoids creating a priavet `test***` in your test file.

The `t.Run` is the biggest trick in here. It uses the provided name to create pretty test results so you know which of your test cases has a failure.