### PR TITLE
ci(workflows): replace setup-ffmpeg action with native package managers

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup FFmpeg
-      uses: federicocarboni/setup-ffmpeg@v3.1
+      run: sudo apt-get install -y ffmpeg
 
     - name: Set up Go
       uses: actions/setup-go@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           go-version: stable
 
       - name: Setup FFmpeg
-        uses: federicocarboni/setup-ffmpeg@v3.1
+        run: brew install ffmpeg
 
       - name: Run tests
         run: go test -v ./...

--- a/main.go
+++ b/main.go
@@ -9,11 +9,17 @@ import (
 var version = "dev"
 
 func main() {
+	versionPtr := flag.Bool("version", false, "Print the version and exit")
 	sourcePtr := flag.String("source", "source", "Directory in which to find original music files")
 	destinationPtr := flag.String("destination", "destination", "Output directory for transcoded files")
 	dryRunPtr := flag.Bool("dry-run", false, "Show which duplicate files would be deleted without deleting them")
 
 	flag.Parse()
+
+	if *versionPtr {
+		fmt.Println(version)
+		os.Exit(0)
+	}
 
 	sourceDir := *sourcePtr
 	destinationDir := *destinationPtr


### PR DESCRIPTION
## Summary

- Replace `federicocarboni/setup-ffmpeg@v3.1` with `brew install ffmpeg` in `release.yml` (macOS runner) to fix ARM64 failure on `macos-latest`
- Replace same action with `sudo apt-get install -y ffmpeg` in `go.yml` (Ubuntu runner) for consistency and to remove Node.js 20 deprecation warning
- Wire pre-existing `version` variable to a `--version` flag to fix staticcheck warning blocking `make validate`